### PR TITLE
Make users soft deletable

### DIFF
--- a/src/main/java/org/kiwiproject/champagne/core/User.java
+++ b/src/main/java/org/kiwiproject/champagne/core/User.java
@@ -26,5 +26,6 @@ public class User {
 
     @NotBlank
     String systemIdentifier;
-    
+
+    boolean deleted;
 }

--- a/src/main/java/org/kiwiproject/champagne/jdbi/UserDao.java
+++ b/src/main/java/org/kiwiproject/champagne/jdbi/UserDao.java
@@ -25,12 +25,21 @@ public interface UserDao {
     @SqlQuery("select * from users where system_identifier = :systemIdentifier")
     Optional<User> findBySystemIdentifier(@Bind("systemIdentifier") String systemIdentifier);
 
-    @SqlQuery("select * from users offset :offset limit :limit")
+    @SqlQuery("select * from users where deleted = false offset :offset limit :limit")
     List<User> findPagedUsers(@Bind("offset") int offset, @Bind("limit") int limit);
 
-    @SqlQuery("select count(*) from users")
+    @SqlQuery("select * from users offset :offset limit :limit")
+    List<User> findPagedUsersIncludingDeleted(@Bind("offset") int offset, @Bind("limit") int limit);
+
+    @SqlQuery("select count(*) from users where deleted = false")
     long countUsers();
 
-    @SqlUpdate("delete from users where id = :id")
+    @SqlQuery("select count(*) from users")
+    long countUsersIncludingDeleted();
+
+    @SqlUpdate("update users set deleted = true where id = :id")
     void deleteUser(@Bind("id") long id);
+
+    @SqlUpdate("update users set deleted = false where id = :id")
+    void reactivateUser(@Bind("id") long id);
 }

--- a/src/main/java/org/kiwiproject/champagne/jdbi/mappers/UserMapper.java
+++ b/src/main/java/org/kiwiproject/champagne/jdbi/mappers/UserMapper.java
@@ -22,6 +22,7 @@ public class UserMapper implements RowMapper<User> {
                 .lastName(r.getString("last_name"))
                 .displayName(r.getString("display_name"))
                 .systemIdentifier(r.getString("system_identifier"))
+                .deleted(r.getBoolean("deleted"))
                 .build();
     }
 }

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -31,4 +31,12 @@
             </column>
         </createTable>
     </changeSet>
+
+    <changeSet id="soft_delete_users" author="crohr">
+        <addColumn tableName="users">
+            <column name="deleted" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Users will be linked to other models in the future and we will want to maintain create and update history even if the user is no longer in the system.

Also add new reactive methods to endpoints and dao. Add ability to list active or all users.

Closes #54