### PR TITLE
Add the recording of auditable events

### DIFF
--- a/src/main/java/org/kiwiproject/champagne/App.java
+++ b/src/main/java/org/kiwiproject/champagne/App.java
@@ -10,6 +10,7 @@ import org.dhatim.dropwizard.jwt.cookie.authentication.JwtCookieAuthBundle;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
 import org.jdbi.v3.postgres.PostgresPlugin;
 import org.kiwiproject.champagne.config.AppConfig;
+import org.kiwiproject.champagne.dao.AuditRecordDao;
 import org.kiwiproject.champagne.dao.DeploymentEnvironmentDao;
 import org.kiwiproject.champagne.dao.ReleaseDao;
 import org.kiwiproject.champagne.dao.ReleaseStatusDao;
@@ -58,6 +59,7 @@ public class App extends Application<AppConfig> {
 
         var jdbi = Jdbi3Builders.buildManagedJdbi(environment, configuration.getDataSourceFactory(), new PostgresPlugin());
         
+        var auditRecordDao = jdbi.onDemand(AuditRecordDao.class);
         var userDao = jdbi.onDemand(UserDao.class);
         var releaseDao = jdbi.onDemand(ReleaseDao.class);
         var releaseStatusDao = jdbi.onDemand(ReleaseStatusDao.class);
@@ -66,8 +68,8 @@ public class App extends Application<AppConfig> {
         var deploymentEnvironmentDao = jdbi.onDemand(DeploymentEnvironmentDao.class);
 
         environment.jersey().register(new AuthResource(userDao));
-        environment.jersey().register(new TaskResource(releaseDao, releaseStatusDao, taskDao, taskStatusDao, deploymentEnvironmentDao));
-        environment.jersey().register(new UserResource(userDao));
+        environment.jersey().register(new TaskResource(releaseDao, releaseStatusDao, taskDao, taskStatusDao, deploymentEnvironmentDao, auditRecordDao));
+        environment.jersey().register(new UserResource(userDao, auditRecordDao));
 
         configureCors(environment);
     }

--- a/src/main/java/org/kiwiproject/champagne/dao/DeploymentEnvironmentDao.java
+++ b/src/main/java/org/kiwiproject/champagne/dao/DeploymentEnvironmentDao.java
@@ -13,13 +13,11 @@ import org.kiwiproject.champagne.dao.mappers.DeploymentEnvironmentMapper;
 
 @RegisterRowMapper(DeploymentEnvironmentMapper.class)
 public interface DeploymentEnvironmentDao {
-    @SqlUpdate("insert into deployment_environments"
-            + " (environment_name, created_by, updated_by)"
-            + " values (:name, :createdById, :updatedById)")
+    @SqlUpdate("insert into deployment_environments (environment_name) values (:name)")
     @GetGeneratedKeys
     long insertEnvironment(@BindBean DeploymentEnvironment env);
 
-    @SqlUpdate("update deployment_environments set environment_name = :name, updated_at = current_timestamp, updated_by = :updatedById where id = :id")
+    @SqlUpdate("update deployment_environments set environment_name = :name, updated_at = current_timestamp where id = :id")
     void updateEnvironment(@BindBean DeploymentEnvironment env);
 
     @SqlQuery("select * from deployment_environments")
@@ -28,10 +26,10 @@ public interface DeploymentEnvironmentDao {
     @SqlUpdate("delete from deployment_environments where id = :id")
     void hardDeleteById(@Bind("id") long id);
 
-    @SqlUpdate("update deployment_environments set deleted = true, updated_at = current_timestamp, updated_by = :updatedById where id = :id")
+    @SqlUpdate("update deployment_environments set deleted = true, updated_at = current_timestamp where id = :id")
     void softDeleteById(@Bind("id") long id, @Bind("updatedById") long updatedById);
 
-    @SqlUpdate("update deployment_environments set deleted = false, updated_at = current_timestamp, updated_by = :updatedById where id = :id")
+    @SqlUpdate("update deployment_environments set deleted = false, updated_at = current_timestamp where id = :id")
     void unSoftDeleteById(@Bind("id") long id, @Bind("updatedById") long updatedById);
 
 }

--- a/src/main/java/org/kiwiproject/champagne/dao/UserDao.java
+++ b/src/main/java/org/kiwiproject/champagne/dao/UserDao.java
@@ -25,21 +25,12 @@ public interface UserDao {
     @SqlQuery("select * from users where system_identifier = :systemIdentifier")
     Optional<User> findBySystemIdentifier(@Bind("systemIdentifier") String systemIdentifier);
 
-    @SqlQuery("select * from users where deleted = false offset :offset limit :limit")
+    @SqlQuery("select * from users offset :offset limit :limit")
     List<User> findPagedUsers(@Bind("offset") int offset, @Bind("limit") int limit);
 
-    @SqlQuery("select * from users offset :offset limit :limit")
-    List<User> findPagedUsersIncludingDeleted(@Bind("offset") int offset, @Bind("limit") int limit);
-
-    @SqlQuery("select count(*) from users where deleted = false")
+    @SqlQuery("select count(*) from users")
     long countUsers();
 
-    @SqlQuery("select count(*) from users")
-    long countUsersIncludingDeleted();
-
-    @SqlUpdate("update users set deleted = true, updated_at = current_timestamp where id = :id")
+    @SqlUpdate("delete from users where id = :id")
     void deleteUser(@Bind("id") long id);
-
-    @SqlUpdate("update users set deleted = false, updated_at = current_timestamp where id = :id")
-    void reactivateUser(@Bind("id") long id);
 }

--- a/src/main/java/org/kiwiproject/champagne/dao/mappers/DeploymentEnvironmentMapper.java
+++ b/src/main/java/org/kiwiproject/champagne/dao/mappers/DeploymentEnvironmentMapper.java
@@ -16,9 +16,7 @@ public class DeploymentEnvironmentMapper implements RowMapper<DeploymentEnvironm
         return DeploymentEnvironment.builder()
                 .id(rs.getLong("id"))
                 .createdAt(instantFromTimestamp(rs, "created_at"))
-                .createdById(rs.getLong("created_by"))
                 .updatedAt(instantFromTimestamp(rs, "updated_at"))
-                .updatedById(rs.getLong("updated_by"))
                 .name(rs.getString("environment_name"))
                 .deleted(rs.getBoolean("deleted"))
                 .build();

--- a/src/main/java/org/kiwiproject/champagne/dao/mappers/UserMapper.java
+++ b/src/main/java/org/kiwiproject/champagne/dao/mappers/UserMapper.java
@@ -22,7 +22,6 @@ public class UserMapper implements RowMapper<User> {
                 .lastName(r.getString("last_name"))
                 .displayName(r.getString("display_name"))
                 .systemIdentifier(r.getString("system_identifier"))
-                .deleted(r.getBoolean("deleted"))
                 .build();
     }
 }

--- a/src/main/java/org/kiwiproject/champagne/model/DeploymentEnvironment.java
+++ b/src/main/java/org/kiwiproject/champagne/model/DeploymentEnvironment.java
@@ -24,9 +24,7 @@ public class DeploymentEnvironment {
     @NotBlank
     String name;
 
-    long createdById;
     Instant createdAt;
-    long updatedById;
     Instant updatedAt;
 
     boolean deleted;

--- a/src/main/java/org/kiwiproject/champagne/resource/AuditableResource.java
+++ b/src/main/java/org/kiwiproject/champagne/resource/AuditableResource.java
@@ -12,7 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public abstract class AuditableResource {
     
-    private AuditRecordDao auditRecordDao;
+    private final AuditRecordDao auditRecordDao;
 
     protected AuditableResource(AuditRecordDao auditRecordDao) {
         this.auditRecordDao = auditRecordDao;

--- a/src/main/java/org/kiwiproject/champagne/resource/AuditableResource.java
+++ b/src/main/java/org/kiwiproject/champagne/resource/AuditableResource.java
@@ -1,0 +1,39 @@
+package org.kiwiproject.champagne.resource;
+
+import java.util.Objects;
+
+import org.dhatim.dropwizard.jwt.cookie.authentication.CurrentPrincipal;
+import org.kiwiproject.champagne.dao.AuditRecordDao;
+import org.kiwiproject.champagne.model.AuditRecord;
+import org.kiwiproject.champagne.model.AuditRecord.Action;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public abstract class AuditableResource {
+    
+    private AuditRecordDao auditRecordDao;
+
+    protected AuditableResource(AuditRecordDao auditRecordDao) {
+        this.auditRecordDao = auditRecordDao;
+    }
+
+    protected void auditAction(long recordId, Class<?> recordClass, Action action) {
+        var principal = CurrentPrincipal.get();
+
+        if (Objects.isNull(principal)) {
+            LOG.warn("No user found in request, unable to track audit of action {} on {} with id {}", action, recordClass.getSimpleName(), recordId);
+            return;
+        }
+
+        var auditRecord = AuditRecord.builder()
+            .recordId(recordId)
+            .recordType(recordClass.getSimpleName())
+            .action(action)
+            .userSystemIdentifier(principal.getName())
+            .build();
+
+        auditRecordDao.insertAuditRecord(auditRecord);
+    }
+
+}

--- a/src/main/java/org/kiwiproject/champagne/resource/ReleaseWithStatus.java
+++ b/src/main/java/org/kiwiproject/champagne/resource/ReleaseWithStatus.java
@@ -10,7 +10,7 @@ import lombok.Value;
 import lombok.experimental.Delegate;
 
 /**
- * This model is used for the {@link TaskResource.class} to combine the release information with all of the statues for the stored environments.
+ * This model is used for the {@link TaskResource} to combine the release information with all of the statues for the stored environments.
  */
 @Value
 @Builder

--- a/src/main/java/org/kiwiproject/champagne/resource/TaskWithStatus.java
+++ b/src/main/java/org/kiwiproject/champagne/resource/TaskWithStatus.java
@@ -10,7 +10,7 @@ import lombok.Value;
 import lombok.experimental.Delegate;
 
 /**
- * This model is used for the {@link TaskResource.class} to combine the task information with all of the statues for the stored environments.
+ * This model is used for the {@link TaskResource} to combine the task information with all of the statues for the stored environments.
  */
 @Value
 @Builder

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -176,4 +176,13 @@
             <column name="audit_timestamp"/>
         </createIndex>
     </changeSet>
+
+    <changeSet id="remove_user_soft_delete_and_user_foriegn_keys" author="crohr">
+        <dropColumn tableName="users" columnName="deleted"/>
+
+        <dropColumn tableName="deployment_environments">
+            <column name="created_by"/>
+            <column name="updated_by"/>
+        </dropColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/src/test/java/org/kiwiproject/champagne/dao/DeploymentEnvironmentDaoTest.java
+++ b/src/test/java/org/kiwiproject/champagne/dao/DeploymentEnvironmentDaoTest.java
@@ -58,8 +58,6 @@ class DeploymentEnvironmentDaoTest {
 
             var envToInsert = DeploymentEnvironment.builder()
                     .name("PRODUCTION")
-                    .createdById(testUserId)
-                    .updatedById(testUserId)
                     .build();
 
             var id = dao.insertEnvironment(envToInsert);
@@ -77,8 +75,6 @@ class DeploymentEnvironmentDaoTest {
             assertTimeDifferenceWithinTolerance(softly, "updatedAt", beforeInsert, env.getUpdatedAt().atZone(ZoneOffset.UTC), 1000L);
 
             softly.assertThat(env.getName()).isEqualTo("PRODUCTION");
-            softly.assertThat(env.getCreatedById()).isEqualTo(testUserId);
-            softly.assertThat(env.getUpdatedById()).isEqualTo(testUserId);
         }
     }
 
@@ -88,26 +84,22 @@ class DeploymentEnvironmentDaoTest {
         @Test
         void shouldUpdateDeploymentEnvironmentSuccessfully(SoftAssertions softly) {
             long envId = insertDeploymentEnvironmentRecord(handle, "TEST", testUserId);
-            long testSecondUser = insertUserRecord(handle, "jadoe");
 
             var envToUpdate = DeploymentEnvironment.builder()
                     .id(envId)
                     .name("PRODUCTION")
-                    .updatedById(testSecondUser)
                     .build();
 
             dao.updateEnvironment(envToUpdate);
 
-            var users = handle.select("select * from deployment_environments where id = ?", envId)
+            var envs = handle.select("select * from deployment_environments where id = ?", envId)
                 .map(new DeploymentEnvironmentMapper())
                 .list();
 
-            assertThat(users).hasSize(1);
+            assertThat(envs).hasSize(1);
 
-            var user = first(users);
+            var user = first(envs);
             softly.assertThat(user.getName()).isEqualTo("PRODUCTION");
-            softly.assertThat(user.getCreatedById()).isEqualTo(1L);
-            softly.assertThat(user.getUpdatedById()).isEqualTo(2L);
         }
     }
 

--- a/src/test/java/org/kiwiproject/champagne/dao/DeploymentEnvironmentDaoTest.java
+++ b/src/test/java/org/kiwiproject/champagne/dao/DeploymentEnvironmentDaoTest.java
@@ -53,7 +53,7 @@ class DeploymentEnvironmentDaoTest {
     class InsertEnvironment {
 
         @Test
-        void shouldInsertUserSuccessfully(SoftAssertions softly) {
+        void shouldInsertUserSuccessfully() {
             var beforeInsert = ZonedDateTime.now();
 
             var envToInsert = DeploymentEnvironment.builder()
@@ -69,12 +69,12 @@ class DeploymentEnvironmentDaoTest {
             assertThat(envs).hasSize(1);
 
             var env = first(envs);
-            softly.assertThat(env.getId()).isEqualTo(id);
+            assertThat(env.getId()).isEqualTo(id);
 
-            assertTimeDifferenceWithinTolerance(softly, "createdAt", beforeInsert, env.getCreatedAt().atZone(ZoneOffset.UTC), 1000L);
-            assertTimeDifferenceWithinTolerance(softly, "updatedAt", beforeInsert, env.getUpdatedAt().atZone(ZoneOffset.UTC), 1000L);
+            assertTimeDifferenceWithinTolerance("createdAt", beforeInsert, env.getCreatedAt().atZone(ZoneOffset.UTC), 1000L);
+            assertTimeDifferenceWithinTolerance("updatedAt", beforeInsert, env.getUpdatedAt().atZone(ZoneOffset.UTC), 1000L);
 
-            softly.assertThat(env.getName()).isEqualTo("PRODUCTION");
+            assertThat(env.getName()).isEqualTo("PRODUCTION");
         }
     }
 
@@ -82,7 +82,7 @@ class DeploymentEnvironmentDaoTest {
     class UpdateUser {
 
         @Test
-        void shouldUpdateDeploymentEnvironmentSuccessfully(SoftAssertions softly) {
+        void shouldUpdateDeploymentEnvironmentSuccessfully() {
             long envId = insertDeploymentEnvironmentRecord(handle, "TEST", testUserId);
 
             var envToUpdate = DeploymentEnvironment.builder()
@@ -99,7 +99,7 @@ class DeploymentEnvironmentDaoTest {
             assertThat(envs).hasSize(1);
 
             var user = first(envs);
-            softly.assertThat(user.getName()).isEqualTo("PRODUCTION");
+            assertThat(user.getName()).isEqualTo("PRODUCTION");
         }
     }
 

--- a/src/test/java/org/kiwiproject/champagne/dao/UserDaoTest.java
+++ b/src/test/java/org/kiwiproject/champagne/dao/UserDaoTest.java
@@ -77,7 +77,6 @@ class UserDaoTest {
             softly.assertThat(user.getFirstName()).isEqualTo("John");
             softly.assertThat(user.getLastName()).isEqualTo("Doe");
             softly.assertThat(user.getDisplayName()).isEqualTo("John Doe");
-            softly.assertThat(user.isDeleted()).isEqualTo(false);
         }
     }
 
@@ -145,8 +144,8 @@ class UserDaoTest {
 
             var users = dao.findPagedUsers(0, 10);
             assertThat(users)
-                .extracting("systemIdentifier", "firstName", "lastName", "deleted")
-                .contains(tuple("fooBar", "Foo", "Bar", false));
+                .extracting("systemIdentifier", "firstName", "lastName")
+                .contains(tuple("fooBar", "Foo", "Bar"));
         }
 
         @Test
@@ -154,28 +153,6 @@ class UserDaoTest {
             insertUserRecord(handle, "fooBar", "Foo", "Bar");
 
             var users = dao.findPagedUsers(10, 10);
-            assertThat(users).isEmpty();
-        }
-    }
-
-    @Nested
-    class FindPagedUsersIncludingDeleted {
-
-        @Test
-        void shouldReturnListOfUsers() {
-            insertUserRecord(handle, "fooBar", "Foo", "Bar", true);
-
-            var users = dao.findPagedUsersIncludingDeleted(0, 10);
-            assertThat(users)
-                    .extracting("systemIdentifier", "firstName", "lastName", "deleted")
-                    .contains(tuple("fooBar", "Foo", "Bar", true));
-        }
-
-        @Test
-        void shouldReturnEmptyListWhenNoUsersFound() {
-            insertUserRecord(handle, "fooBar", "Foo", "Bar");
-
-            var users = dao.findPagedUsersIncludingDeleted(10, 10);
             assertThat(users).isEmpty();
         }
     }
@@ -199,24 +176,6 @@ class UserDaoTest {
     }
 
     @Nested
-    class CountUsersIncludingDeleted {
-
-        @Test
-        void shouldReturnCountOfUsers() {
-            insertUserRecord(handle, "fooBar", "Foo", "Bar", true);
-
-            var count = dao.countUsersIncludingDeleted();
-            assertThat(count).isOne();
-        }
-
-        @Test
-        void shouldReturnZeroWhenNoUsersFound() {
-            var count = dao.countUsersIncludingDeleted();
-            assertThat(count).isZero();
-        }
-    }
-
-    @Nested
     class DeleteUser {
 
         @Test
@@ -226,30 +185,7 @@ class UserDaoTest {
             dao.deleteUser(userId);
 
             var users = handle.select("select * from users where id = ?", userId).map(new UserMapper()).list();
-            assertThat(users).hasSize(1);
-
-            var user = first(users);
-            softly.assertThat(user.getId()).isEqualTo(userId);
-            softly.assertThat(user.isDeleted()).isEqualTo(true);
-        }
-
-    }
-
-    @Nested
-    class ReactivateUser {
-
-        @Test
-        void shouldReactivateUserSuccessfully(SoftAssertions softly) {
-            var userId = insertUserRecord(handle, "jdoe", "John", "Doe", true);
-
-            dao.reactivateUser(userId);
-
-            var users = handle.select("select * from users where id = ?", userId).map(new UserMapper()).list();
-            assertThat(users).hasSize(1);
-
-            var user = first(users);
-            softly.assertThat(user.getId()).isEqualTo(userId);
-            softly.assertThat(user.isDeleted()).isEqualTo(false);
+            assertThat(users).isEmpty();
         }
 
     }

--- a/src/test/java/org/kiwiproject/champagne/resource/AuditableResourceTest.java
+++ b/src/test/java/org/kiwiproject/champagne/resource/AuditableResourceTest.java
@@ -1,0 +1,101 @@
+package org.kiwiproject.champagne.resource;
+
+import static org.kiwiproject.test.jaxrs.JaxrsTestHelper.assertOkResponse;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import io.dropwizard.testing.junit5.ResourceExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kiwiproject.champagne.dao.AuditRecordDao;
+import org.kiwiproject.champagne.model.AuditRecord;
+import org.kiwiproject.champagne.model.User;
+import org.kiwiproject.champagne.util.AuthHelper;
+import org.kiwiproject.jaxrs.exception.JaxrsExceptionMapper;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+@DisplayName("AuditableResource")
+@ExtendWith(DropwizardExtensionsSupport.class)
+class AuditableResourceTest {
+
+    private static final AuditRecordDao AUDIT_RECORD_DAO = mock(AuditRecordDao.class);
+
+    private static final TestResource TEST_RESOURCE = new TestResource(AUDIT_RECORD_DAO);
+
+    private static final ResourceExtension APP = ResourceExtension.builder()
+            .bootstrapLogging(false)
+            .addResource(TEST_RESOURCE)
+            .addProvider(JaxrsExceptionMapper.class)
+            .build();
+
+    @AfterEach
+    void clearMocks() {
+        reset(AUDIT_RECORD_DAO);
+    }
+
+    @Nested
+    class AuditAction {
+
+        @Test
+        void shouldRecordActionWhenPrincipalExists() {
+            TEST_RESOURCE.setupAuth = true;
+
+            var response = APP.client().target("/record")
+                    .request()
+                    .get();
+
+            assertOkResponse(response);
+
+            verify(AUDIT_RECORD_DAO).insertAuditRecord(argThat(auditRecord -> auditRecord.getUserSystemIdentifier().equals("Bob")));
+        }
+
+        @Test
+        void shouldNotRecordActionWhenPrincipalIsMissing() {
+            TEST_RESOURCE.setupAuth = false;
+
+            var response = APP.client().target("/record")
+                    .request()
+                    .get();
+
+            assertOkResponse(response);
+
+            verifyNoInteractions(AUDIT_RECORD_DAO);
+        }
+    }
+
+    @Path("/")
+    public static class TestResource extends AuditableResource {
+
+        public boolean setupAuth;
+
+        public TestResource(AuditRecordDao auditRecordDao) {
+            super(auditRecordDao);
+        }
+
+        @GET
+        @Path("/record")
+        public Response noAuth() {
+            if (setupAuth) {
+                AuthHelper.setupCurrentPrincipalFor("Bob");
+            }
+
+            auditAction(1L, User.class, AuditRecord.Action.CREATED);
+
+            // Always remove just in case
+            AuthHelper.removePrincipal();
+
+            return Response.ok().build();
+        }
+
+    }
+}

--- a/src/test/java/org/kiwiproject/champagne/resource/TaskResourceTest.java
+++ b/src/test/java/org/kiwiproject/champagne/resource/TaskResourceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -23,17 +24,21 @@ import java.util.Optional;
 import javax.ws.rs.core.GenericType;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.kiwiproject.champagne.model.DeploymentEnvironment;
+import org.kiwiproject.champagne.model.AuditRecord.Action;
 import org.kiwiproject.champagne.model.manualdeployment.DeploymentTaskStatus;
 import org.kiwiproject.champagne.model.manualdeployment.Release;
 import org.kiwiproject.champagne.model.manualdeployment.ReleaseStage;
 import org.kiwiproject.champagne.model.manualdeployment.ReleaseStatus;
 import org.kiwiproject.champagne.model.manualdeployment.Task;
 import org.kiwiproject.champagne.model.manualdeployment.TaskStatus;
+import org.kiwiproject.champagne.util.AuthHelper;
+import org.kiwiproject.champagne.dao.AuditRecordDao;
 import org.kiwiproject.champagne.dao.DeploymentEnvironmentDao;
 import org.kiwiproject.champagne.dao.ReleaseDao;
 import org.kiwiproject.champagne.dao.ReleaseStatusDao;
@@ -55,8 +60,9 @@ class TaskResourceTest {
     private static final TaskDao TASK_DAO = mock(TaskDao.class);
     private static final TaskStatusDao TASK_STATUS_DAO = mock(TaskStatusDao.class);
     private static final DeploymentEnvironmentDao DEPLOYMENT_ENVIRONMENT_DAO = mock(DeploymentEnvironmentDao.class);
+    private static final AuditRecordDao AUDIT_RECORD_DAO = mock(AuditRecordDao.class);
 
-    private static final TaskResource RESOURCE = new TaskResource(RELEASE_DAO, RELEASE_STATUS_DAO, TASK_DAO, TASK_STATUS_DAO, DEPLOYMENT_ENVIRONMENT_DAO);
+    private static final TaskResource RESOURCE = new TaskResource(RELEASE_DAO, RELEASE_STATUS_DAO, TASK_DAO, TASK_STATUS_DAO, DEPLOYMENT_ENVIRONMENT_DAO, AUDIT_RECORD_DAO);
 
     private static final ResourceExtension RESOURCES = ResourceExtension.builder()
         .bootstrapLogging(false)
@@ -65,9 +71,15 @@ class TaskResourceTest {
         .addProvider(JaxrsExceptionMapper.class)
         .build();
 
+    @BeforeEach
+    void setUp() {
+        AuthHelper.setupCurrentPrincipalFor("bob");
+    }
+
     @AfterEach
     void cleanup() {
-        reset(RELEASE_DAO, RELEASE_STATUS_DAO, TASK_DAO, TASK_STATUS_DAO, DEPLOYMENT_ENVIRONMENT_DAO);
+        reset(RELEASE_DAO, RELEASE_STATUS_DAO, TASK_DAO, TASK_STATUS_DAO, DEPLOYMENT_ENVIRONMENT_DAO, AUDIT_RECORD_DAO);
+        AuthHelper.removePrincipal();
     }
 
     @Nested
@@ -115,7 +127,7 @@ class TaskResourceTest {
             verify(RELEASE_STATUS_DAO).findByReleaseId(1L);
 
             verifyNoMoreInteractions(RELEASE_DAO, RELEASE_STATUS_DAO);
-            verifyNoInteractions(TASK_DAO, TASK_STATUS_DAO, DEPLOYMENT_ENVIRONMENT_DAO);
+            verifyNoInteractions(TASK_DAO, TASK_STATUS_DAO, DEPLOYMENT_ENVIRONMENT_DAO, AUDIT_RECORD_DAO);
         }
 
         @Test
@@ -159,7 +171,7 @@ class TaskResourceTest {
             verify(RELEASE_STATUS_DAO).findByReleaseId(1L);
 
             verifyNoMoreInteractions(RELEASE_DAO, RELEASE_STATUS_DAO);
-            verifyNoInteractions(TASK_DAO, TASK_STATUS_DAO, DEPLOYMENT_ENVIRONMENT_DAO);
+            verifyNoInteractions(TASK_DAO, TASK_STATUS_DAO, DEPLOYMENT_ENVIRONMENT_DAO, AUDIT_RECORD_DAO);
         }
     }
     
@@ -210,7 +222,7 @@ class TaskResourceTest {
             verify(TASK_STATUS_DAO).findByTaskId(1L);
 
             verifyNoMoreInteractions(TASK_DAO, TASK_STATUS_DAO);
-            verifyNoInteractions(RELEASE_DAO, RELEASE_STATUS_DAO, DEPLOYMENT_ENVIRONMENT_DAO);
+            verifyNoInteractions(RELEASE_DAO, RELEASE_STATUS_DAO, DEPLOYMENT_ENVIRONMENT_DAO, AUDIT_RECORD_DAO);
         }
     }
 
@@ -232,6 +244,8 @@ class TaskResourceTest {
 
             when(DEPLOYMENT_ENVIRONMENT_DAO.findAllEnvironments()).thenReturn(List.of(env));
 
+            when(RELEASE_STATUS_DAO.insertReleaseStatus(any(ReleaseStatus.class))).thenReturn(2L);
+
             var response = RESOURCES.client()
                 .target("/manual/deployment/tasks/releases")
                 .request()
@@ -243,7 +257,10 @@ class TaskResourceTest {
             verify(RELEASE_STATUS_DAO).insertReleaseStatus(any(ReleaseStatus.class));
             verify(DEPLOYMENT_ENVIRONMENT_DAO).findAllEnvironments();
 
-            verifyNoMoreInteractions(RELEASE_DAO, RELEASE_STATUS_DAO, DEPLOYMENT_ENVIRONMENT_DAO);
+            verifyAuditRecorded(1L, Release.class, Action.CREATED);
+            verifyMultipleStatusRecordsAuditRecorded(1, ReleaseStatus.class, Action.CREATED);
+
+            verifyNoMoreInteractions(RELEASE_DAO, RELEASE_STATUS_DAO, DEPLOYMENT_ENVIRONMENT_DAO, AUDIT_RECORD_DAO);
             verifyNoInteractions(TASK_DAO, TASK_STATUS_DAO);
         }
     }
@@ -311,7 +328,11 @@ class TaskResourceTest {
             verify(RELEASE_STATUS_DAO).updateStatus(5L, DeploymentTaskStatus.COMPLETE);
             verify(DEPLOYMENT_ENVIRONMENT_DAO).findAllEnvironments();
 
-            verifyNoMoreInteractions(TASK_DAO, TASK_STATUS_DAO, RELEASE_STATUS_DAO, DEPLOYMENT_ENVIRONMENT_DAO);
+            verifyAuditRecorded(2L, Task.class, Action.CREATED);
+            verifyMultipleStatusRecordsAuditRecorded(1, TaskStatus.class, Action.CREATED);
+            verifyMultipleStatusRecordsAuditRecorded(1, ReleaseStatus.class, Action.UPDATED);
+
+            verifyNoMoreInteractions(TASK_DAO, TASK_STATUS_DAO, RELEASE_STATUS_DAO, DEPLOYMENT_ENVIRONMENT_DAO, AUDIT_RECORD_DAO);
             verifyNoInteractions(RELEASE_DAO);
 
         }
@@ -334,6 +355,8 @@ class TaskResourceTest {
             assertAcceptedResponse(response);
 
             verify(RELEASE_STATUS_DAO).updateStatus(1L, DeploymentTaskStatus.COMPLETE);
+
+            verifyAuditRecorded(1L, ReleaseStatus.class, Action.UPDATED);
         }
 
         @Test
@@ -368,6 +391,8 @@ class TaskResourceTest {
             assertAcceptedResponse(response);
 
             verify(TASK_STATUS_DAO).updateStatus(1L, DeploymentTaskStatus.COMPLETE);
+
+            verifyAuditRecorded(1L, TaskStatus.class, Action.UPDATED);
         }
 
         @Test
@@ -398,6 +423,8 @@ class TaskResourceTest {
 
             assertAcceptedResponse(response);
             verify(RELEASE_DAO).deleteById(1L);
+
+            verifyAuditRecorded(1L, Release.class, Action.DELETED);
         }
     }
 
@@ -421,6 +448,8 @@ class TaskResourceTest {
 
             assertAcceptedResponse(response);
             verify(TASK_DAO).deleteById(1L);
+
+            verifyAuditRecorded(1L, Task.class, Action.DELETED);
         }
 
         @Test
@@ -453,7 +482,7 @@ class TaskResourceTest {
             verify(RELEASE_STATUS_DAO).findByReleaseId(1L);
 
             verifyNoMoreInteractions(TASK_DAO, RELEASE_STATUS_DAO);
-            verifyNoInteractions(TASK_STATUS_DAO, RELEASE_DAO);
+            verifyNoInteractions(TASK_STATUS_DAO, RELEASE_DAO, AUDIT_RECORD_DAO);
         }
 
         private ReleaseStatus newReleaseStatus(DeploymentTaskStatus status) {
@@ -482,7 +511,7 @@ class TaskResourceTest {
             verify(RELEASE_STATUS_DAO).findByReleaseId(1L);
 
             verifyNoMoreInteractions(TASK_DAO, RELEASE_STATUS_DAO, TASK_STATUS_DAO);
-            verifyNoInteractions(RELEASE_DAO);
+            verifyNoInteractions(RELEASE_DAO, AUDIT_RECORD_DAO);
         }
 
         private TaskStatus newTaskStatus(DeploymentTaskStatus status) {
@@ -511,7 +540,9 @@ class TaskResourceTest {
             verify(RELEASE_STATUS_DAO).findByReleaseId(1L);
             verify(RELEASE_STATUS_DAO).updateStatus(1L, DeploymentTaskStatus.COMPLETE);
 
-            verifyNoMoreInteractions(TASK_DAO, RELEASE_STATUS_DAO, TASK_STATUS_DAO);
+            verifyAuditRecorded(1L, ReleaseStatus.class, Action.UPDATED);
+
+            verifyNoMoreInteractions(TASK_DAO, RELEASE_STATUS_DAO, TASK_STATUS_DAO, AUDIT_RECORD_DAO);
             verifyNoInteractions(RELEASE_DAO);
         }
 
@@ -536,7 +567,9 @@ class TaskResourceTest {
             verify(RELEASE_STATUS_DAO).findByReleaseId(1L);
             verify(RELEASE_STATUS_DAO).updateStatus(1L, DeploymentTaskStatus.COMPLETE);
 
-            verifyNoMoreInteractions(TASK_DAO, RELEASE_STATUS_DAO, TASK_STATUS_DAO);
+            verifyAuditRecorded(1L, ReleaseStatus.class, Action.UPDATED);
+
+            verifyNoMoreInteractions(TASK_DAO, RELEASE_STATUS_DAO, TASK_STATUS_DAO, AUDIT_RECORD_DAO);
             verifyNoInteractions(RELEASE_DAO);
         }
 
@@ -558,7 +591,9 @@ class TaskResourceTest {
             verify(RELEASE_STATUS_DAO).findByReleaseId(1L);
             verify(RELEASE_STATUS_DAO).updateStatus(1L, DeploymentTaskStatus.NOT_REQUIRED);
 
-            verifyNoMoreInteractions(TASK_DAO, RELEASE_STATUS_DAO, TASK_STATUS_DAO);
+            verifyAuditRecorded(1L, ReleaseStatus.class, Action.UPDATED);
+
+            verifyNoMoreInteractions(TASK_DAO, RELEASE_STATUS_DAO, TASK_STATUS_DAO, AUDIT_RECORD_DAO);
             verifyNoInteractions(RELEASE_DAO);
         }
 
@@ -582,8 +617,9 @@ class TaskResourceTest {
             verify(TASK_STATUS_DAO).findByTaskId(3L);
             verify(RELEASE_STATUS_DAO).findByReleaseId(1L);
             verify(RELEASE_STATUS_DAO).updateStatus(1L, DeploymentTaskStatus.NOT_REQUIRED);
+            verifyAuditRecorded(1L, ReleaseStatus.class, Action.UPDATED);
 
-            verifyNoMoreInteractions(TASK_DAO, RELEASE_STATUS_DAO, TASK_STATUS_DAO);
+            verifyNoMoreInteractions(TASK_DAO, RELEASE_STATUS_DAO, TASK_STATUS_DAO, AUDIT_RECORD_DAO);
             verifyNoInteractions(RELEASE_DAO);
         }
 
@@ -607,8 +643,9 @@ class TaskResourceTest {
             verify(TASK_STATUS_DAO).findByTaskId(3L);
             verify(RELEASE_STATUS_DAO).findByReleaseId(1L);
             verify(RELEASE_STATUS_DAO).updateStatus(1L, DeploymentTaskStatus.PENDING);
+            verifyAuditRecorded(1L, ReleaseStatus.class, Action.UPDATED);
 
-            verifyNoMoreInteractions(TASK_DAO, RELEASE_STATUS_DAO, TASK_STATUS_DAO);
+            verifyNoMoreInteractions(TASK_DAO, RELEASE_STATUS_DAO, TASK_STATUS_DAO, AUDIT_RECORD_DAO);
             verifyNoInteractions(RELEASE_DAO);
         }
 
@@ -634,8 +671,9 @@ class TaskResourceTest {
             verify(TASK_STATUS_DAO).findByTaskId(3L);
             verify(RELEASE_STATUS_DAO).findByReleaseId(1L);
             verify(RELEASE_STATUS_DAO).updateStatus(1L, DeploymentTaskStatus.PENDING);
+            verifyAuditRecorded(1L, ReleaseStatus.class, Action.UPDATED);
 
-            verifyNoMoreInteractions(TASK_DAO, RELEASE_STATUS_DAO, TASK_STATUS_DAO);
+            verifyNoMoreInteractions(TASK_DAO, RELEASE_STATUS_DAO, TASK_STATUS_DAO, AUDIT_RECORD_DAO);
             verifyNoInteractions(RELEASE_DAO);
         }
 
@@ -661,9 +699,42 @@ class TaskResourceTest {
             verify(TASK_STATUS_DAO).findByTaskId(3L);
             verify(RELEASE_STATUS_DAO).findByReleaseId(1L);
             verify(RELEASE_STATUS_DAO).updateStatus(1L, DeploymentTaskStatus.COMPLETE);
+            verifyAuditRecorded(1L, ReleaseStatus.class, Action.UPDATED);
 
-            verifyNoMoreInteractions(TASK_DAO, RELEASE_STATUS_DAO, TASK_STATUS_DAO);
+            verifyNoMoreInteractions(TASK_DAO, RELEASE_STATUS_DAO, TASK_STATUS_DAO, AUDIT_RECORD_DAO);
             verifyNoInteractions(RELEASE_DAO);
         }
+    }
+
+    private void verifyAuditRecorded(long id, Class<?> taskClass, Action action) {
+        verify(AUDIT_RECORD_DAO).insertAuditRecord(argThat(audit -> {
+            return audit.getRecordId() == id 
+                && audit.getRecordType().equalsIgnoreCase(taskClass.getSimpleName()) 
+                && audit.getAction() == action;
+        }));
+
+        // var argCapture = ArgumentCaptor.forClass(AuditRecord.class);
+        // verify(AUDIT_RECORD_DAO).insertAuditRecord(argCapture.capture());
+
+        // var audit = argCapture.getValue();
+
+        // assertThat(audit.getRecordId()).isEqualTo(id);
+        // assertThat(audit.getRecordType()).isEqualTo(taskClass.getSimpleName());
+        // assertThat(audit.getAction()).isEqualTo(action);
+    }
+
+    private void verifyMultipleStatusRecordsAuditRecorded(int times, Class<?> statusClass, Action action) {
+        verify(AUDIT_RECORD_DAO, times(times)).insertAuditRecord(argThat(audit -> {
+            return audit.getRecordType().equalsIgnoreCase(statusClass.getSimpleName()) 
+                && audit.getAction() == action;
+        }));
+
+        // var argCapture = ArgumentCaptor.forClass(AuditRecord.class);
+        // verify(AUDIT_RECORD_DAO, times(times)).insertAuditRecord(argCapture.capture());
+
+        // var audit = argCapture.getValue();
+
+        // assertThat(audit.getRecordType()).isEqualTo(statusClass.getSimpleName());
+        // assertThat(audit.getAction()).isEqualTo(action);
     }
 }

--- a/src/test/java/org/kiwiproject/champagne/resource/TaskResourceTest.java
+++ b/src/test/java/org/kiwiproject/champagne/resource/TaskResourceTest.java
@@ -712,15 +712,6 @@ class TaskResourceTest {
                 && audit.getRecordType().equalsIgnoreCase(taskClass.getSimpleName()) 
                 && audit.getAction() == action;
         }));
-
-        // var argCapture = ArgumentCaptor.forClass(AuditRecord.class);
-        // verify(AUDIT_RECORD_DAO).insertAuditRecord(argCapture.capture());
-
-        // var audit = argCapture.getValue();
-
-        // assertThat(audit.getRecordId()).isEqualTo(id);
-        // assertThat(audit.getRecordType()).isEqualTo(taskClass.getSimpleName());
-        // assertThat(audit.getAction()).isEqualTo(action);
     }
 
     private void verifyMultipleStatusRecordsAuditRecorded(int times, Class<?> statusClass, Action action) {
@@ -728,13 +719,5 @@ class TaskResourceTest {
             return audit.getRecordType().equalsIgnoreCase(statusClass.getSimpleName()) 
                 && audit.getAction() == action;
         }));
-
-        // var argCapture = ArgumentCaptor.forClass(AuditRecord.class);
-        // verify(AUDIT_RECORD_DAO, times(times)).insertAuditRecord(argCapture.capture());
-
-        // var audit = argCapture.getValue();
-
-        // assertThat(audit.getRecordType()).isEqualTo(statusClass.getSimpleName());
-        // assertThat(audit.getAction()).isEqualTo(action);
     }
 }

--- a/src/test/java/org/kiwiproject/champagne/util/AuthHelper.java
+++ b/src/test/java/org/kiwiproject/champagne/util/AuthHelper.java
@@ -1,0 +1,36 @@
+package org.kiwiproject.champagne.util;
+
+import java.security.Principal;
+
+import org.dhatim.dropwizard.jwt.cookie.authentication.CurrentPrincipal;
+import org.dhatim.dropwizard.jwt.cookie.authentication.DefaultJwtCookiePrincipal;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class AuthHelper {
+    
+    public static void setupCurrentPrincipalFor(String username) {
+        var principal = new DefaultJwtCookiePrincipal(username);
+
+        try {
+            var method = CurrentPrincipal.class.getDeclaredMethod("set", Principal.class);
+            method.setAccessible(true);
+
+            method.invoke(null, principal);
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to set user", e);
+        }
+    }
+
+    public static void removePrincipal() {
+        try {
+            var method = CurrentPrincipal.class.getDeclaredMethod("remove");
+            method.setAccessible(true);
+
+            method.invoke(null);
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to remove user", e);
+        }
+    }
+}

--- a/src/test/java/org/kiwiproject/champagne/util/AuthHelper.java
+++ b/src/test/java/org/kiwiproject/champagne/util/AuthHelper.java
@@ -4,6 +4,7 @@ import java.security.Principal;
 
 import org.dhatim.dropwizard.jwt.cookie.authentication.CurrentPrincipal;
 import org.dhatim.dropwizard.jwt.cookie.authentication.DefaultJwtCookiePrincipal;
+import org.kiwiproject.reflect.RuntimeReflectionException;
 
 import lombok.experimental.UtilityClass;
 
@@ -19,7 +20,7 @@ public class AuthHelper {
 
             method.invoke(null, principal);
         } catch (Exception e) {
-            throw new RuntimeException("Unable to set user", e);
+            throw new RuntimeReflectionException("Unable to set user", e);
         }
     }
 
@@ -30,7 +31,7 @@ public class AuthHelper {
 
             method.invoke(null);
         } catch (Exception e) {
-            throw new RuntimeException("Unable to remove user", e);
+            throw new RuntimeReflectionException("Unable to remove user", e);
         }
     }
 }

--- a/src/test/java/org/kiwiproject/champagne/util/TestObjects.java
+++ b/src/test/java/org/kiwiproject/champagne/util/TestObjects.java
@@ -35,11 +35,9 @@ public class TestObjects {
     public static long insertDeploymentEnvironmentRecord(Handle handle, String name, long userId) {
         var testDeploymentEnvironmentRecord = DeploymentEnvironment.builder()
             .name(name)
-            .createdById(userId)
-            .updatedById(userId)
             .build();
 
-        return handle.createUpdate("insert into deployment_environments (environment_name, created_by, updated_by) values (:name, :createdById, :updatedById)")
+        return handle.createUpdate("insert into deployment_environments (environment_name) values (:name)")
             .bindBean(testDeploymentEnvironmentRecord)
             .executeAndReturnGeneratedKeys("id")
             .mapTo(Long.class)
@@ -51,19 +49,14 @@ public class TestObjects {
     }
 
     public static long insertUserRecord(Handle handle, String systemIdentifier, String firstName, String lastName) {
-        return insertUserRecord(handle, systemIdentifier, firstName, lastName, false);
-    }
-
-    public static long insertUserRecord(Handle handle, String systemIdentifier, String firstName, String lastName, boolean deleted) {
         var testUserRecord = User.builder()
             .systemIdentifier(systemIdentifier)
             .firstName(firstName)
             .lastName(lastName)
             .displayName(firstName + " " + lastName)
-            .deleted(deleted)
             .build();
 
-        return handle.createUpdate("insert into users (system_identifier, first_name, last_name, display_name, deleted) values (:systemIdentifier, :firstName, :lastName, :displayName, :deleted)")
+        return handle.createUpdate("insert into users (system_identifier, first_name, last_name, display_name) values (:systemIdentifier, :firstName, :lastName, :displayName)")
             .bindBean(testUserRecord)
             .executeAndReturnGeneratedKeys("id")
             .mapTo(Long.class)


### PR DESCRIPTION
These events occur when a model is created, updated, or deleted in the database.

Also remove the foreign keys between DeploymentEnvironment and User since that link was used to track audits.

A ticket will be created to add the CRUD endpoints for DeploymentEnvironments

Closes #58