### PR TITLE
Add admin flag to users

### DIFF
--- a/service/src/main/java/org/kiwiproject/champagne/dao/UserDao.java
+++ b/service/src/main/java/org/kiwiproject/champagne/dao/UserDao.java
@@ -15,11 +15,11 @@ import org.kiwiproject.champagne.dao.mappers.UserMapper;
 @RegisterRowMapper(UserMapper.class)
 public interface UserDao {
     
-    @SqlUpdate("insert into users (first_name, last_name, display_name, system_identifier) values (:firstName, :lastName, :displayName, :systemIdentifier)")
+    @SqlUpdate("insert into users (first_name, last_name, display_name, system_identifier, admin) values (:firstName, :lastName, :displayName, :systemIdentifier, :admin)")
     @GetGeneratedKeys
     long insertUser(@BindBean User user);
 
-    @SqlUpdate("update users set first_name = :firstName, last_name = :lastName, display_name = :displayName, system_identifier = :systemIdentifier, updated_at = now() where id = :id")
+    @SqlUpdate("update users set first_name = :firstName, last_name = :lastName, display_name = :displayName, system_identifier = :systemIdentifier, admin = :admin, updated_at = now() where id = :id")
     void updateUser(@BindBean User user);
 
     @SqlQuery("select * from users where system_identifier = :systemIdentifier")

--- a/service/src/main/java/org/kiwiproject/champagne/dao/mappers/UserMapper.java
+++ b/service/src/main/java/org/kiwiproject/champagne/dao/mappers/UserMapper.java
@@ -22,6 +22,7 @@ public class UserMapper implements RowMapper<User> {
                 .lastName(r.getString("last_name"))
                 .displayName(r.getString("display_name"))
                 .systemIdentifier(r.getString("system_identifier"))
+                .admin(r.getBoolean("admin"))
                 .build();
     }
 }

--- a/service/src/main/java/org/kiwiproject/champagne/model/User.java
+++ b/service/src/main/java/org/kiwiproject/champagne/model/User.java
@@ -32,4 +32,6 @@ public class User {
 
     @NotBlank
     String systemIdentifier;
+
+    boolean admin;
 }

--- a/service/src/main/java/org/kiwiproject/champagne/resource/AuditRecordResource.java
+++ b/service/src/main/java/org/kiwiproject/champagne/resource/AuditRecordResource.java
@@ -3,6 +3,7 @@ package org.kiwiproject.champagne.resource;
 import static org.kiwiproject.search.KiwiSearching.zeroBasedOffset;
 
 import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -30,6 +31,7 @@ public class AuditRecordResource {
     private final AuditRecordDao auditRecordDao;
 
     @GET
+    @RolesAllowed("admin")
     @Timed
     @ExceptionMetered
     public Response getPagedAudits(@QueryParam("pageNumber") @DefaultValue("1") int pageNumber,

--- a/service/src/main/java/org/kiwiproject/champagne/resource/AuthResource.java
+++ b/service/src/main/java/org/kiwiproject/champagne/resource/AuthResource.java
@@ -11,6 +11,8 @@ import org.kiwiproject.jaxrs.exception.JaxrsNotAuthorizedException;
 
 import static java.util.Objects.isNull;
 
+import java.util.List;
+
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.POST;
@@ -45,7 +47,9 @@ public class AuthResource {
             throw new JaxrsNotAuthorizedException("Invalid login");
         }
 
-        var principal = new DefaultJwtCookiePrincipal(user.getSystemIdentifier());
+        List<String> roles = user.isAdmin() ? List.of("admin") : List.of();
+
+        var principal = new DefaultJwtCookiePrincipal(user.getSystemIdentifier(), false, roles, null);
         principal.addInContext(context);
 
         return Response.ok(user).build();

--- a/service/src/main/java/org/kiwiproject/champagne/resource/UserResource.java
+++ b/service/src/main/java/org/kiwiproject/champagne/resource/UserResource.java
@@ -15,6 +15,7 @@ import org.kiwiproject.champagne.model.User;
 import org.kiwiproject.spring.data.KiwiPage;
 
 import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
@@ -58,6 +59,7 @@ public class UserResource extends AuditableResource {
     }
 
     @POST
+    @RolesAllowed("admin")
     @Timed
     @ExceptionMetered
     public Response addUser(@NotNull @Valid User user) {
@@ -70,6 +72,7 @@ public class UserResource extends AuditableResource {
 
     @DELETE
     @Path("/{id}")
+    @RolesAllowed("admin")
     @Timed
     @ExceptionMetered
     public Response deleteUser(@PathParam("id") long id) {

--- a/service/src/main/resources/migrations.xml
+++ b/service/src/main/resources/migrations.xml
@@ -270,4 +270,12 @@
             </column>
         </createTable>
     </changeSet>
+
+    <changeSet id="add_admin_flag_to_users" author="crohr">
+        <addColumn tableName="users">
+            <column name="admin" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/service/src/test/java/org/kiwiproject/champagne/dao/UserDaoTest.java
+++ b/service/src/test/java/org/kiwiproject/champagne/dao/UserDaoTest.java
@@ -77,7 +77,9 @@ class UserDaoTest {
             softly.assertThat(user.getFirstName()).isEqualTo("John");
             softly.assertThat(user.getLastName()).isEqualTo("Doe");
             softly.assertThat(user.getDisplayName()).isEqualTo("John Doe");
+            softly.assertThat(user.isAdmin()).isFalse();
         }
+
     }
 
     @Nested

--- a/service/src/test/java/org/kiwiproject/champagne/resource/AuthResourceTest.java
+++ b/service/src/test/java/org/kiwiproject/champagne/resource/AuthResourceTest.java
@@ -72,6 +72,26 @@ class AuthResourceTest {
             //       that the cookie is being set correctly. Currently response.getCookies() returns an empty map.
             //       Probably need to figure out how to access/use the ContainerRequestContext in the test.
         }
+
+        @Test
+        void shouldReturnJwtAsCookieWhenLoginIsSuccessfulAndUserIsAdmin() {
+            var user = User.builder()
+                    .systemIdentifier("jdoe")
+                    .admin(true)
+                    .build();
+
+            when(USER_DAO.findBySystemIdentifier("jdoe")).thenReturn(Optional.of(user));
+
+            var response = APP.client().target("/auth/login")
+                    .request()
+                    .post(json(Map.of("username", "jdoe")));
+
+            assertOkResponse(response);
+            // TODO: When the bundle is added, a cookie is setup in the response, need to figure out how to test
+            //       that the cookie is being set correctly. Currently response.getCookies() returns an empty map.
+            //       Probably need to figure out how to access/use the ContainerRequestContext in the test.
+            //       Will need to check the claims as well for the role
+        }
     }
 
     @Nested

--- a/ui/src/layouts/MainLayout.vue
+++ b/ui/src/layouts/MainLayout.vue
@@ -21,6 +21,21 @@
           <div class="text-h4 text-grey-4">Champagne</div>
           <div class="text-caption text-grey-4">Toasting successful deployments</div>
         </q-toolbar-title>
+
+        <q-space />
+
+        <q-btn round flat v-if="authStore.isLoggedIn">
+          <q-avatar size="26px" class="bg-grey-4 text-grey-9">
+            {{ authStore.loggedInUserAvatar }}
+          </q-avatar>
+          <q-menu>
+            <q-list>
+              <q-item clickable v-close-popup @click="authStore.logout()">
+                <q-item-section>Logout</q-item-section>
+              </q-item>
+            </q-list>
+          </q-menu>
+        </q-btn>
       </q-toolbar>
     </q-header>
 
@@ -93,7 +108,7 @@
             </q-item-section>
           </q-item>
 
-          <q-item to="/audits" exact clickable v-ripple>
+          <q-item to="/audits" exact clickable v-ripple v-if="authStore.isAdmin">
             <q-item-section avatar>
               <q-icon name="assignment"/>
             </q-item-section>

--- a/ui/src/stores/auth.js
+++ b/ui/src/stores/auth.js
@@ -7,6 +7,13 @@ export const useAuthStore = defineStore('auth', () => {
   const returnUrl = ref(null)
 
   const isLoggedIn = computed(() => user.value !== null)
+  const isAdmin = computed(() => user.value !== null && user.value.admin)
+  const loggedInUserAvatar = computed(() => {
+    if (user.value === null) {
+      return ''
+    }
+    return `${user.value.firstName.charAt(0)}${user.value.lastName.charAt(0)}`
+  })
 
   async function login (username, password) {
     const response = await api.post('/auth/login', { username })
@@ -27,5 +34,5 @@ export const useAuthStore = defineStore('auth', () => {
     this.router.push('/login')
   }
 
-  return { user, returnUrl, isLoggedIn, login, logout }
+  return { user, returnUrl, isLoggedIn, isAdmin, loggedInUserAvatar, login, logout }
 })

--- a/ui/src/stores/userStore.js
+++ b/ui/src/stores/userStore.js
@@ -17,7 +17,7 @@ export const useUserStore = defineStore('user', () => {
   }
 
   function create (userData) {
-    api.post('/users', userData)
+    return api.post('/users', userData)
       .then(() => load())
   }
 

--- a/ui/test/vitest/__tests__/pages/UserPage.spec.js
+++ b/ui/test/vitest/__tests__/pages/UserPage.spec.js
@@ -40,6 +40,7 @@ describe('updateDisplayName', () => {
 describe('createUser', () => {
   it('should call the user store to create a new user', () => {
     const userStore = useUserStore()
+    userStore.create.mockImplementation(() => Promise.resolve(1))
 
     wrapper.vm.activeUser.firstName = 'Bob'
     wrapper.vm.activeUser.lastName = 'Roberts'
@@ -48,7 +49,7 @@ describe('createUser', () => {
 
     wrapper.vm.createUser()
 
-    expect(userStore.create).toHaveBeenLastCalledWith({ firstName: 'Bob', lastName: 'Roberts', displayName: 'Bob Roberts', systemIdentifier: 'brob' })
+    expect(userStore.create).toHaveBeenLastCalledWith({ firstName: 'Bob', lastName: 'Roberts', displayName: 'Bob Roberts', systemIdentifier: 'brob', admin: false })
     expect(wrapper.vm.showUserAdd).toEqual(false)
   })
 })

--- a/ui/test/vitest/__tests__/stores/auth.spec.js
+++ b/ui/test/vitest/__tests__/stores/auth.spec.js
@@ -1,7 +1,7 @@
 import { setActivePinia, createPinia } from 'pinia'
 import { useAuthStore } from 'src/stores/auth'
-import { vi } from "vitest";
-import { api } from "src/boot/axios";
+import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest'
+import { api } from 'src/boot/axios'
 
 describe('Auth Store', () => {
   beforeEach(() => {
@@ -12,46 +12,101 @@ describe('Auth Store', () => {
     vi.resetAllMocks()
   })
 
-  it('login', async () => {
-    vi.mock('src/boot/axios', () => {
-      const api = {
-        post: vi.fn().mockImplementation(() => Promise.resolve({data: { username: 'joe' }}))
+  describe('login', () => {
+    it('should login the user', async () => {
+      vi.mock('src/boot/axios', () => {
+        const api = {
+          post: vi.fn().mockImplementation(() => Promise.resolve({ data: { username: 'joe' } }))
+        }
+
+        return { api }
+      })
+
+      const mockRouter = {
+        push: vi.fn()
       }
 
-      return { api }
+      const authStore = useAuthStore()
+      authStore.router = mockRouter
+
+      await authStore.login('joe', 'password')
+
+      expect(api.post).toHaveBeenCalled()
+      expect(api.post).toHaveBeenCalledWith('/auth/login', { username: 'joe' })
+      expect(authStore.user).toEqual({ username: 'joe' })
+      expect(sessionStorage.getItem('champagne-user')).toEqual(JSON.stringify({ username: 'joe' }))
+      expect(authStore.router.push).toHaveBeenCalled()
+      expect(authStore.router.push).toHaveBeenCalledWith('/')
+    })
+  })
+
+  describe('logout', () => {
+    it('should logout the user', () => {
+      const mockRouter = {
+        push: vi.fn()
+      }
+
+      const authStore = useAuthStore()
+      authStore.router = mockRouter
+
+      authStore.logout()
+
+      expect(authStore.user).toBeNull()
+      expect(sessionStorage.getItem('champagne-user')).toBeNull()
+      expect(authStore.router.push).toHaveBeenCalled()
+      expect(authStore.router.push).toHaveBeenCalledWith('/login')
+    })
+  })
+
+  describe('isLoggedIn', () => {
+    it('should return true when logged in', () => {
+      const authStore = useAuthStore()
+      authStore.user = {}
+
+      expect(authStore.isLoggedIn).toBeTruthy()
     })
 
-    const mockRouter = {
-      push: vi.fn()
-    }
+    it('should return false when not logged in', () => {
+      const authStore = useAuthStore()
 
-    const authStore = useAuthStore()
-    authStore.router = mockRouter
-
-    await authStore.login('joe', 'password')
-
-    expect(api.post).toHaveBeenCalled()
-    expect(api.post).toHaveBeenCalledWith('/auth/login', { username: 'joe' })
-    expect(authStore.user).toEqual({ username: 'joe' })
-    expect(sessionStorage.getItem('champagne-user')).toEqual(JSON.stringify({ username: 'joe' }))
-    expect(authStore.router.push).toHaveBeenCalled()
-    expect(authStore.router.push).toHaveBeenCalledWith('/')
+      expect(authStore.isLoggedIn).toBeFalsy()
+    })
   })
 
-  it('logout', () => {
-    const mockRouter = {
-      push: vi.fn()
-    }
+  describe('isAdmin', () => {
+    it('should return true when logged in and is and admin', () => {
+      const authStore = useAuthStore()
+      authStore.user = { admin: true }
 
-    const authStore = useAuthStore()
-    authStore.router = mockRouter
+      expect(authStore.isAdmin).toBeTruthy()
+    })
 
-    authStore.logout()
+    it('should return false when not logged in', () => {
+      const authStore = useAuthStore()
 
-    expect(authStore.user).toBeNull()
-    expect(sessionStorage.getItem('champagne-user')).toBeNull()
-    expect(authStore.router.push).toHaveBeenCalled()
-    expect(authStore.router.push).toHaveBeenCalledWith('/login')
+      expect(authStore.isAdmin).toBeFalsy()
+    })
+
+    it('should return false when logged in but not an admin', () => {
+      const authStore = useAuthStore()
+      authStore.user = { admin: false }
+
+      expect(authStore.isAdmin).toBeFalsy()
+    })
   })
 
+  describe('loggedInUserAvatar', () => {
+    it('should return initials when user is logged in', () => {
+      const authStore = useAuthStore()
+      authStore.user = { firstName: 'Joe', lastName: 'Schmoo' }
+
+      expect(authStore.loggedInUserAvatar).toEqual('JS')
+    })
+
+    it('should return empty string when not logged in', () => {
+      const authStore = useAuthStore()
+
+      expect(authStore.loggedInUserAvatar).toEqual('')
+    })
+  })
 })


### PR DESCRIPTION
* Add field to User model and migration to add column in db
* Update User endpoints delete and create to restrict to admins only
* Update Auth resource to set roles on principal
* Update Audit endpoint to restrict to admins
* Update UI Layout to hide Audit page if not an admin
* Update UI Layout to add logged in avatar and logout action
* Update User UI to add admin indicator to rows
* Update User UI to hide add and delete actions if not an admin
* Update User UI to allow for setting admin flag on create
* Update various tests (ui and service)

Closes #63